### PR TITLE
Feature: Breathing LED error levels

### DIFF
--- a/Controllers/CLedsController.cpp
+++ b/Controllers/CLedsController.cpp
@@ -14,7 +14,6 @@ CLedsController::CLedsController(
 				UBaseType_t priority)
 		    : CController(run_period, name, stack_depth, priority)
 {
-	// TODO Auto-generated constructor stub
 
 }
 
@@ -24,6 +23,7 @@ void CLedsController::run()
 
     while (true)
     {
+    	// Set BREATHING LED PWM
     	m_led_duty += (m_led_direction*m_led_speed);
 
     	if(m_led_duty >= 100)
@@ -45,8 +45,29 @@ void CLedsController::run()
     	__HAL_TIM_SET_COMPARE(m_htim, m_channel, pulse);
 
     	vTaskDelay(m_run_period_override); //Ignore m_run_period variable set by user
-
-    	//TODO: Add events to change the speed of the LED
     }
+}
+
+/**
+ * @brief Set system error level to change the LED speed.
+ * The error levels are defined in main.h and are of the type:
+ * SYSTEM_OK,
+ * SYSTEM_WARNING,
+ * SYSTEM_ERROR
+ */
+void CLedsController::setLevel(error_types_t error)
+{
+	switch(error)
+	{
+	case SYSTEM_ERROR:
+		m_led_speed = LED_SPEED_VERY_HIGH;
+		break;
+	case SYSTEM_WARNING:
+		m_led_speed = LED_SPEED_HIGH;
+		break;
+	case SYSTEM_OK:
+	default:
+		m_led_speed = LED_SPEED_NORMAL;
+	}
 }
 

--- a/Controllers/CLedsController.h
+++ b/Controllers/CLedsController.h
@@ -20,8 +20,18 @@ public:
 
 	virtual void run();
 
+	void setLevel(error_types_t error);
+
 private:
-	uint32_t m_led_speed = 3; // This will determine how fast the LED turns on/off. 3 is a "soothing" speed.
+
+	enum
+	{
+		LED_SPEED_NORMAL = 3,
+		LED_SPEED_HIGH = 10,
+		LED_SPEED_VERY_HIGH = 50
+	};
+
+	uint32_t m_led_speed = LED_SPEED_NORMAL;
 	int32_t m_led_duty = 0;
 	int8_t m_led_direction = 1; // Set to 1 if the LED is turning on, -1 if off.
 

--- a/Core/Inc/main.h
+++ b/Core/Inc/main.h
@@ -54,6 +54,15 @@ void Error_Handler(void);
 
 /* USER CODE BEGIN EFP */
 
+typedef enum
+{
+	SYSTEM_OK,
+	SYSTEM_WARNING,
+	SYSTEM_ERROR
+}error_types_t;
+
+extern void setErrorLevel(error_types_t error_level);
+
 /* USER CODE END EFP */
 
 /* Private defines -----------------------------------------------------------*/

--- a/Lib/Src/CTaskBase.cpp
+++ b/Lib/Src/CTaskBase.cpp
@@ -18,9 +18,7 @@ CTaskBase::CTaskBase(const etl::string<configMAX_TASK_NAME_LEN> name,
 
 CTaskBase::~CTaskBase()
 {
-	// Stop task and delete it
-	vTaskSuspend(m_task_handle);
-	vTaskDelete(m_task_handle);
+	setErrorLevel(SYSTEM_ERROR);
 }
 
 bool CTaskBase::start()

--- a/Lib/Src/Controllers.cpp
+++ b/Lib/Src/Controllers.cpp
@@ -39,6 +39,11 @@ extern "C"
         g_leds_controller.start();
     }
 
+    void setErrorLevel(error_types_t error_level)
+    {
+    	g_leds_controller.setLevel(error_level);
+    }
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
* Add system levels to control the speed of the Breathing LED. 
* The levels are: SYSTEM_OK, SYSTEM_WARNING and SYSTEM_ERROR